### PR TITLE
Add C-u prefix to `mf/save-original-buffers` to select the buffer

### DIFF
--- a/multifiles.el
+++ b/multifiles.el
@@ -35,11 +35,13 @@
 (require 'dash)
 
 (defun mf/mirror-region-in-multifile (beg end &optional multifile-buffer)
-  (interactive "r")
+  (interactive (list (region-beginning) (region-end)
+                     (when current-prefix-arg
+                       (read-buffer "Mirror into buffer: " "*multifile*"))))
   (deactivate-mark)
   (let ((buffer (current-buffer))
         (mode major-mode))
-    (switch-to-buffer-other-window (or "*multifile*" multifile-buffer))
+    (switch-to-buffer-other-window (or multifile-buffer "*multifile*"))
     (funcall mode)
     (multifiles-minor-mode 1)
     (mf--add-mirror buffer beg end)


### PR DESCRIPTION
Without prefix, the mirrors go by default to `*multifile*`, otherwise you can `read-buffer` into which the mirror goes. I've found it super cool to pull parts of buffers into different "default" buffer with code. Imagine pulling a bit of utility.c into main.c, then narrowing... bloody genius!
