### PR TITLE
Multifile-mirror the files that are marked in a dired buffer.

### DIFF
--- a/multifiles.el
+++ b/multifiles.el
@@ -55,6 +55,15 @@
 
 (define-key multifiles-minor-mode-map (vector 'remap 'save-buffer) 'mf/save-original-buffers)
 
+(defun mf/dired-mirror-marked-files ()
+  "Multifile-mirror the files that are marked in a `dired' buffer."
+  (interactive)
+  (mapcar
+   (lambda (buffer)
+     (with-current-buffer buffer
+       (mf/mirror-region-in-multifile (point-min) (point-max))))
+   (mapcar 'find-file-noselect (dired-get-marked-files))))
+
 (defun mf/save-original-buffers ()
   (interactive)
   (when (yes-or-no-p "Are you sure you want to save all original files?")

--- a/multifiles.el
+++ b/multifiles.el
@@ -58,7 +58,7 @@
 (defun mf/dired-mirror-marked-files ()
   "Multifile-mirror the files that are marked in a `dired' buffer."
   (interactive)
-  (mapcar
+  (mapc
    (lambda (buffer)
      (with-current-buffer buffer
        (mf/mirror-region-in-multifile (point-min) (point-max))))

--- a/multifiles.el
+++ b/multifiles.el
@@ -62,7 +62,7 @@
    (lambda (buffer)
      (with-current-buffer buffer
        (mf/mirror-region-in-multifile (point-min) (point-max))))
-   (mapcar 'find-file-noselect (dired-get-marked-files))))
+   (mapcar 'find-file (dired-get-marked-files))))
 
 (defun mf/save-original-buffers ()
   (interactive)


### PR DESCRIPTION
Useful for editing and comparing those tiny yasnippet files with really short un-ido-able buffer names.
